### PR TITLE
Change build_id to be per project/env instead of global

### DIFF
--- a/src/entity.d.ts
+++ b/src/entity.d.ts
@@ -1,4 +1,4 @@
-type ApiResponse<T> = ApiResponseSuccess<T> | ApiResponseError;
+type ApiResponse<T = unknown> = ApiResponseSuccess<T> | ApiResponseError;
 
 interface ApiResponseSuccess<T> {
 	success: true;
@@ -11,13 +11,6 @@ interface ApiResponseError {
 	code: number;
 	error: string;
 	stack?: string;
-}
-
-interface Project {
-	project_id: number;
-	user_id: number;
-	name: string;
-	description: string;
 }
 
 // Responses

--- a/worker/migrations/0001_cloudy_serpent_society.sql
+++ b/worker/migrations/0001_cloudy_serpent_society.sql
@@ -1,0 +1,29 @@
+-- SQLite (what D1 runs) is very limited in SQL annoyingly and doesn't let us modify columns
+-- therefore, we're gonna need to make a new table, move the data over, and then delete the old table
+-- in order to remove the PK + autoincrement on build_id
+
+-- Taken from migration 0000
+CREATE TABLE IF NOT EXISTS `builds_new` (
+	`build_id` integer NOT NULL,
+	`release_channel_id` integer NOT NULL,
+	`project_id` integer NOT NULL,
+	`file_hash` text NOT NULL,
+	`supported_versions` text NOT NULL,
+	`dependencies` text NOT NULL,
+	`release_notes` text NOT NULL,
+	FOREIGN KEY (`release_channel_id`) REFERENCES `release_channels`(`release_channel_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`project_id`) ON UPDATE no action ON DELETE cascade,
+	PRIMARY KEY (`build_id`, `release_channel_id`)
+);
+
+-- Copy data over
+INSERT INTO builds_new SELECT * FROM builds;
+
+-- Rename the old table
+ALTER TABLE builds RENAME TO builds_old;
+
+-- Rename the new table to be active
+ALTER TABLE builds_new RENAME TO builds;
+
+-- Drop the old table
+-- DROP TABLE builds_old;

--- a/worker/migrations/meta/0001_snapshot.json
+++ b/worker/migrations/meta/0001_snapshot.json
@@ -1,0 +1,291 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "1639bee3-8c8d-49e2-b633-8615a8e68d54",
+  "prevId": "3150f545-d399-414a-8727-e94b478a0969",
+  "tables": {
+    "builds": {
+      "name": "builds",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_channel_id": {
+          "name": "release_channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supported_versions": {
+          "name": "supported_versions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_notes": {
+          "name": "release_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_release_channel_id_release_channels_release_channel_id_fk": {
+          "name": "builds_release_channel_id_release_channels_release_channel_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "release_channels",
+          "columnsFrom": [
+            "release_channel_id"
+          ],
+          "columnsTo": [
+            "release_channel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "builds_project_id_projects_project_id_fk": {
+          "name": "builds_project_id_projects_project_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "builds_build_id_release_channel_id_pk": {
+          "columns": [
+            "build_id",
+            "release_channel_id"
+          ],
+          "name": "builds_build_id_release_channel_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_user_id_fk": {
+          "name": "projects_user_id_users_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "release_channels": {
+      "name": "release_channels",
+      "columns": {
+        "release_channel_id": {
+          "name": "release_channel_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supported_versions": {
+          "name": "supported_versions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_naming": {
+          "name": "file_naming",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "release_channels_name_idx": {
+          "name": "release_channels_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "release_channels_project_id_projects_project_id_fk": {
+          "name": "release_channels_project_id_projects_project_id_fk",
+          "tableFrom": "release_channels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_api_token_unique": {
+          "name": "users_api_token_unique",
+          "columns": [
+            "api_token"
+          ],
+          "isUnique": true
+        },
+        "users_name_idx": {
+          "name": "users_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "users_api_token_idx": {
+          "name": "users_api_token_idx",
+          "columns": [
+            "api_token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/worker/migrations/meta/_journal.json
+++ b/worker/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1700968690505,
       "tag": "0000_woozy_blue_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1701053976812,
+      "tag": "0001_cloudy_serpent_society",
+      "breakpoints": true
     }
   ]
 }

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "20.10.0",
         "drizzle-kit": "0.20.4",
         "typescript": "5.3.2",
+        "vite-tsconfig-paths": "4.2.1",
         "vitest": "0.34.6",
         "wrangler": "3.17.1"
       }
@@ -1568,6 +1569,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/hanji": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/hanji/-/hanji-0.0.5.tgz",
@@ -2325,6 +2332,26 @@
         "@sentry/utils": "7.76.0"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
+      "integrity": "sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "typescript": "^4.3.5 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -2464,6 +2491,25 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.1.tgz",
+      "integrity": "sha512-GNUI6ZgPqT3oervkvzU+qtys83+75N/OuDaQl7HmOqFTb0pjZsuARrRipsyJhJ3enqV8beI1xhGbToR4o78nSQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -5,9 +5,13 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "#comment": "-- Dev --",
+    "dev": "wrangler dev --env dev",
+    "test": "vitest",
+    "#comment2": "-- Deploy --",
     "deploy:dev": "wrangler deploy --env dev",
     "deploy:prod": "wrangler deploy --env production",
-    "dev": "wrangler dev --env dev",
+    "#comment3": "-- Migrations --",
     "migrate:generate": "drizzle-kit generate:sqlite --out=migrations --schema=./src/store/schema.ts",
     "migrate:local": "wrangler d1 migrations apply DB --env dev --local",
     "migrate:seed-local": "wrangler d1 execute DB --env dev --local --file migrations/seed/seed.sql",
@@ -28,6 +32,7 @@
     "@types/node": "20.10.0",
     "drizzle-kit": "0.20.4",
     "typescript": "5.3.2",
+    "vite-tsconfig-paths": "4.2.1",
     "vitest": "0.34.6",
     "wrangler": "3.17.1"
   }

--- a/worker/src/api/errors.ts
+++ b/worker/src/api/errors.ts
@@ -16,10 +16,17 @@ export const RouteNotFound = new ApiError({
 
 // Input errors
 /**
- * MISSING_FIELD: 1000,
 INVALID_TYPE: 1001,
 INVALID_CHECKSUM: 1003,
  */
+export function MissingField(field: string) {
+	return new ApiError({
+		code: 1000,
+		errorMessage: `Missing field: ${field}`,
+		statusCode: StatusCode.BAD_REQUEST,
+	});
+}
+
 export function InvalidJson(errorMessage: string) {
 	return new ApiError({
 		code: 1002,

--- a/worker/src/handlers/builds/build.ts
+++ b/worker/src/handlers/builds/build.ts
@@ -115,11 +115,11 @@ export async function postUploadBuild(ctx: Ctx, file: File, metadata: UploadMeta
 		return errors.InvalidUpload('Checksum does not match').toResponse(ctx);
 	}
 
-	const lastBuildId = await BuildStore.getLastBuildId();
-	if (lastBuildId === undefined) {
+	const buildCount = await BuildStore.getBuildCount(project.projectId, releaseChannel.releaseChannelId);
+	if (buildCount === undefined) {
 		return errors.InternalError.toResponse(ctx);
 	}
-	const nextBuildId = lastBuildId + 1;
+	const nextBuildId = buildCount.count + 1;
 
 	// Modify the version
 	const jsZip = new JSZip();
@@ -164,7 +164,6 @@ export async function postUploadBuild(ctx: Ctx, file: File, metadata: UploadMeta
 	});
 
 	// Add build to database
-	// TODO: Make build ID per project
 	await BuildStore.insertNewBuild({
 		buildId: nextBuildId,
 		releaseChannelId: releaseChannel.releaseChannelId,

--- a/worker/src/handlers/test/db.ts
+++ b/worker/src/handlers/test/db.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { success } from '~/api/api';
+import * as errors from '~/api/errors';
+import { queryRow } from '~/store/_db';
+import { Project, ReleaseChannel, User, projects, releaseChannels, users } from '~/store/schema';
+import { Ctx } from '~/types/hono';
+import { getDb } from '~/utils/storage';
+
+export const dbQuerySchema = z.object({
+	whatDo: z.enum(['newUser', 'newProject', 'newReleaseChannel', 'raw']),
+
+	user: z.object({
+		userId: z.number(),
+		name: z.string(),
+		apiToken: z.string(),
+	}).optional(),
+
+	project: z.object({
+		projectId: z.number(),
+		name: z.string(),
+		description: z.string(),
+		userId: z.number(),
+	}).optional(),
+
+	releaseChannel: z.object({
+		releaseChannelId: z.number(),
+		projectId: z.number(),
+		name: z.string(),
+		supportedVersions: z.string(),
+		dependencies: z.array(z.string()),
+		fileNaming: z.string(),
+	}).optional(),
+
+	query: z.string().optional(),
+});
+
+export type DbQueryBody = z.infer<typeof dbQuerySchema>;
+
+export async function dbQueryHandler(ctx: Ctx, body: DbQueryBody) {
+	if (body.whatDo === 'newUser') {
+		if (body.user === undefined) {
+			return errors.MissingField('user').toResponse(ctx);
+		}
+
+		const user = await getDb().insert(users).values(body.user as User).returning().get();
+
+		return success('Success', user);
+	} else if (body.whatDo === 'newProject') {
+		if (body.project === undefined) {
+			return errors.MissingField('project').toResponse(ctx);
+		}
+
+		const project = await getDb().insert(projects).values(body.project as Project).returning().get();
+
+		return success('Success', project);
+	}  else if (body.whatDo === 'newReleaseChannel') {
+		if (body.releaseChannel === undefined) {
+			return errors.MissingField('releaseChannel').toResponse(ctx);
+		}
+
+		const releaseChannel = await getDb().insert(releaseChannels)
+			.values(body.releaseChannel as ReleaseChannel)
+			.returning()
+			.get();
+
+		return success('Success', releaseChannel);
+	} else if (body.whatDo === 'raw') {
+		if (body.query === undefined) {
+			return errors.MissingField('query').toResponse(ctx);
+		}
+
+		const result = await queryRow(ctx.env.DB, body.query);
+
+		return success('Success', result);
+	} else {
+		return errors.MissingField('whatDo').toResponse(ctx);
+	}
+}

--- a/worker/src/handlers/test/middleware.ts
+++ b/worker/src/handlers/test/middleware.ts
@@ -1,0 +1,10 @@
+import { Next } from 'hono';
+import * as errors from '~/api/errors';
+import { Ctx } from '~/types/hono';
+
+export async function testOnlyMiddleware(ctx: Ctx, next: Next): Promise<Response | void> {
+	if (ctx.env.ENVIRONMENT !== 'test') {
+		return errors.RouteNotFound.toResponse(ctx as Ctx);
+	}
+	return next();
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,6 +15,8 @@ import {
 	newProjectSchema,
 	postNewProject,
 } from '~/handlers/projects/project';
+import { dbQueryHandler, dbQuerySchema } from '~/handlers/test/db';
+import { testOnlyMiddleware } from '~/handlers/test/middleware';
 import { auth } from '~/middleware/auth';
 import { Ctx } from '~/types/hono';
 import jsonValidator from '~/utils/validator/jsonValidator';
@@ -96,5 +98,9 @@ app.get(
 
 app.onError((err, ctx) => errors.InternalError.withError(err).toResponse(ctx as Ctx));
 app.notFound((ctx) => errors.RouteNotFound.toResponse(ctx as Ctx));
+
+// Test only
+app.use('/__test/*', testOnlyMiddleware);
+app.post('/__test/db', jsonValidator(dbQuerySchema, dbQueryHandler));
 
 export default app;

--- a/worker/src/store/schema.ts
+++ b/worker/src/store/schema.ts
@@ -1,4 +1,4 @@
-import { index, int, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, int, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 // TODO: Auth stuff
 export const users = sqliteTable('users', {
@@ -40,7 +40,7 @@ export type ReleaseChannel = typeof releaseChannels.$inferSelect;
 export type InsertReleaseChannel = typeof releaseChannels.$inferInsert;
 
 export const builds = sqliteTable('builds', {
-	buildId: integer('build_id').primaryKey({ autoIncrement: true }),
+	buildId: integer('build_id'),
 	releaseChannelId: integer('release_channel_id').notNull()
 		.references(() => releaseChannels.releaseChannelId, { onDelete: 'cascade' }),
 	projectId: integer('project_id').notNull().references(() => projects.projectId, { onDelete: 'cascade' }),
@@ -48,7 +48,9 @@ export const builds = sqliteTable('builds', {
 	supportedVersions: text('supported_versions').notNull(),
 	dependencies: text('dependencies', { mode: 'json' }).notNull().$type<string[]>(),
 	releaseNotes: text('release_notes').notNull(),
-});
+}, (table) => ({
+	pk: primaryKey({ columns: [table.buildId, table.releaseChannelId] }),
+}));
 
 export type Build = typeof builds.$inferSelect;
 export type BuildWithReleaseChannel = Build & { releaseChannel: string };

--- a/worker/tests/routes/api/builds/upload.test.ts
+++ b/worker/tests/routes/api/builds/upload.test.ts
@@ -1,0 +1,231 @@
+import { createMockJarFile, createMockProject, createMockUser, setupWorker } from 'tests/testutils/test';
+import { describe, test, expect, beforeAll } from 'vitest';
+import { UnstableDevWorker } from 'wrangler';
+import * as errors from '~/api/errors';
+import { Project, ReleaseChannel, User } from '~/store/schema';
+
+describe('Test uploads', () => {
+	let worker: UnstableDevWorker;
+	let user: User;
+	let project: Project;
+	let devReleaseChannel: ReleaseChannel;
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	let releaseReleaseChannel: ReleaseChannel;
+
+	beforeAll(async () => {
+		worker = await setupWorker();
+
+		user = await createMockUser(worker);
+		const created = await createMockProject(worker, user, undefined, [{ name: 'dev' }, { name: 'release' }]);
+		project = created.project;
+		devReleaseChannel = created.releaseChannels[0];
+		releaseReleaseChannel = created.releaseChannels[1];
+	});
+
+	describe('Invalid form data', () => {
+		test('No form data', async () => {
+			// Test no form data
+			const formData = new FormData();
+
+			const res = await worker.fetch(
+				`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${user.apiToken}`,
+					},
+					// @ts-expect-error - unstable_dev doesn't use workers-types
+					body: formData,
+				},
+			);
+
+			expect(res.status).toBe(400);
+
+			const json = await res.json() as ApiResponse;
+			expect(json.success).toBe(false);
+			if (json.success === true) {
+				throw new Error('Expected success to be false');
+			}
+
+			expect(json.code).toBe(errors.InvalidUpload('').getCode());
+			expect(json.error).toBe(errors.InvalidUpload('File not provided').getErrorMessage());
+		});
+
+		test('No file', async () => {
+			// Test just no file
+			const formData = new FormData();
+			formData.append('metadata', JSON.stringify({ checksum: '' }));
+
+			const res = await worker.fetch(
+				`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${user.apiToken}`,
+					},
+					// @ts-expect-error - unstable_dev doesn't use workers-types
+					body: formData,
+				},
+			);
+
+			expect(res.status).toBe(400);
+
+			const json = await res.json() as ApiResponse;
+			expect(json.success).toBe(false);
+			if (json.success === true) {
+				throw new Error('Expected success to be false');
+			}
+
+			expect(json.code).toBe(errors.InvalidUpload('').getCode());
+			expect(json.error).toBe(errors.InvalidUpload('File not provided').getErrorMessage());
+		});
+
+		test('No metadata', async () => {
+			// Test just no metadata
+			const formData = new FormData();
+			formData.append('file', new Blob(['test'], { type: 'application/java-archive' }), 'test.jar');
+
+			const res = await worker.fetch(
+				`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${user.apiToken}`,
+					},
+					// @ts-expect-error - unstable_dev doesn't use workers-types
+					body: formData,
+				},
+			);
+
+			expect(res.status).toBe(400);
+
+			const json = await res.json() as ApiResponse;
+			expect(json.success).toBe(false);
+			if (json.success === true) {
+				throw new Error('Expected success to be false');
+			}
+
+			expect(json.code).toBe(errors.InvalidUpload('').getCode());
+			expect(json.error).toBe(errors.InvalidUpload('Metadata not provided').getErrorMessage());
+		});
+
+		test('Not jar', async () => {
+			// Test just no metadata
+			const formData = new FormData();
+			formData.append('file', new Blob(['test'], { type: 'plain/text' }), 'test.txt');
+			formData.append('metadata', JSON.stringify({
+				checksum: 'f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2',
+			}));
+
+			const res = await worker.fetch(
+				`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${user.apiToken}`,
+					},
+					// @ts-expect-error - unstable_dev doesn't use workers-types
+					body: formData,
+				},
+			);
+
+			expect(res.status).toBe(400);
+
+			const json = await res.json() as ApiResponse;
+			expect(json.success).toBe(false);
+			if (json.success === true) {
+				throw new Error('Expected success to be false');
+			}
+
+			expect(json.code).toBe(errors.InvalidUpload('').getCode());
+			expect(json.error).toBe(errors.InvalidUpload('File must be a jar file').getErrorMessage());
+		});
+
+		test('Missing checksum', async () => {
+			// Test just no metadata
+			const formData = new FormData();
+			formData.append('file', new Blob(['test'], { type: 'application/java-archive' }), 'test.jar');
+			formData.append('metadata', JSON.stringify({
+				checksum: '',
+			}));
+
+			const res = await worker.fetch(
+				`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${user.apiToken}`,
+					},
+					// @ts-expect-error - unstable_dev doesn't use workers-types
+					body: formData,
+				},
+			);
+
+			expect(res.status).toBe(400);
+
+			const json = await res.json() as ApiResponse;
+			expect(json.success).toBe(false);
+			if (json.success === true) {
+				throw new Error('Expected success to be false');
+			}
+
+			expect(json.code).toBe(errors.InvalidJson('').getCode());
+			expect(json.error).toBe(errors.InvalidJson('String must contain exactly 64 character(s)').getErrorMessage());
+		});
+
+		test('Invalid checksum', async () => {
+			// Test just no metadata
+			const formData = new FormData();
+			formData.append('file', new Blob(['test'], { type: 'application/java-archive' }), 'test.jar');
+			formData.append('metadata', JSON.stringify({
+				checksum: 'a'.repeat(64),
+			}));
+
+			const res = await worker.fetch(
+				`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${user.apiToken}`,
+					},
+					// @ts-expect-error - unstable_dev doesn't use workers-types
+					body: formData,
+				},
+			);
+
+			expect(res.status).toBe(400);
+
+			const json = await res.json() as ApiResponse;
+			expect(json.success).toBe(false);
+			if (json.success === true) {
+				throw new Error('Expected success to be false');
+			}
+
+			expect(json.code).toBe(errors.InvalidUpload('').getCode());
+			expect(json.error).toBe(errors.InvalidUpload('Checksum does not match').getErrorMessage());
+		});
+
+		// TODO: Plugin.yml testing
+	});
+
+	test('Can upload', async () => {
+		const jarFile = await createMockJarFile();
+
+		const formData = new FormData();
+		formData.append('file', jarFile.blob, 'test.jar');
+		formData.append('metadata', JSON.stringify({
+			checksum: '9cd3aad23d91918404f0c619a4bbe92afbebc78288006d4ffe5ae12e97155df8',
+		}));
+
+		const res = await worker.fetch(`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${user.apiToken}`,
+			},
+			// @ts-expect-error - unstable_dev doesn't use workers-types
+			body: formData,
+		});
+
+		expect(res.status).toBe(200);
+
+		const json = await res.json() as ApiResponse;
+		expect(json.success).toBe(true);
+		if (json.success === false) {
+			throw new Error('Expected success to be true');
+		}
+	});
+});

--- a/worker/tests/routes/api/builds/upload.test.ts
+++ b/worker/tests/routes/api/builds/upload.test.ts
@@ -2,7 +2,7 @@ import { createMockJarFile, createMockProject, createMockUser, setupWorker } fro
 import { describe, test, expect, beforeAll } from 'vitest';
 import { UnstableDevWorker } from 'wrangler';
 import * as errors from '~/api/errors';
-import { Project, ReleaseChannel, User } from '~/store/schema';
+import { Build, Project, ReleaseChannel, User } from '~/store/schema';
 
 describe('Test uploads', () => {
 	let worker: UnstableDevWorker;
@@ -201,25 +201,28 @@ describe('Test uploads', () => {
 
 		// TODO: Plugin.yml testing
 	});
+});
+
+describe('Test uploads', () => {
+	let worker: UnstableDevWorker;
+	let user: User;
+	let project: Project;
+	let devReleaseChannel: ReleaseChannel;
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	let releaseReleaseChannel: ReleaseChannel;
+
+	beforeAll(async () => {
+		worker = await setupWorker();
+
+		user = await createMockUser(worker);
+		const created = await createMockProject(worker, user, undefined, [{ name: 'dev' }, { name: 'release' }]);
+		project = created.project;
+		devReleaseChannel = created.releaseChannels[0];
+		releaseReleaseChannel = created.releaseChannels[1];
+	});
 
 	test('Can upload', async () => {
-		const jarFile = await createMockJarFile();
-
-		const formData = new FormData();
-		formData.append('file', jarFile.blob, 'test.jar');
-		formData.append('metadata', JSON.stringify({
-			checksum: '9cd3aad23d91918404f0c619a4bbe92afbebc78288006d4ffe5ae12e97155df8',
-		}));
-
-		const res = await worker.fetch(`https://worker.local/api/builds/${project.name}/${devReleaseChannel.name}/upload`, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${user.apiToken}`,
-			},
-			// @ts-expect-error - unstable_dev doesn't use workers-types
-			body: formData,
-		});
-
+		const res = await uploadFile(worker, user, project.name, devReleaseChannel.name);
 		expect(res.status).toBe(200);
 
 		const json = await res.json() as ApiResponse;
@@ -227,5 +230,200 @@ describe('Test uploads', () => {
 		if (json.success === false) {
 			throw new Error('Expected success to be true');
 		}
+
+		// Confirm build exists
+		const builds = await getBuilds<{ dev: Build[] }>(worker, project);
+		expect(builds.dev).toBeDefined();
+		expect(builds.dev.length).toBe(1);
+
+		const build = builds.dev[0];
+		expect(build.buildId).toBe(1);
+	});
+
+	test('Can upload multiple builds', async () => {
+		const { project, releaseChannels } = await createMockProject(worker, user, undefined, [{ name: 'dev' }]);
+		const devChannel = releaseChannels[0];
+
+		const res = await uploadFile(worker, user, project.name, devChannel.name);
+		expect(res.status).toBe(200);
+
+		const json = await res.json() as ApiResponse;
+		expect(json.success).toBe(true);
+		if (json.success === false) {
+			throw new Error('Expected success to be true');
+		}
+
+		// Confirm build exists
+		const builds = await getBuilds<{ dev: Build[] }>(worker, project);
+		expect(builds.dev).toBeDefined();
+		expect(builds.dev.length).toBe(1);
+
+		const build = builds.dev[0];
+		expect(build.buildId).toBe(1);
+
+		// Upload second build
+		const secondRes = await uploadFile(worker, user, project.name, devChannel.name);
+		expect(secondRes.status).toBe(200);
+
+		const secondJson = await secondRes.json() as ApiResponse;
+		expect(secondJson.success).toBe(true);
+		if (secondJson.success === false) {
+			throw new Error('Expected success to be true');
+		}
+
+		// Confirm build exists
+		const builds2 = await getBuilds<{ dev: Build[] }>(worker, project);
+		expect(builds2.dev).toBeDefined();
+		expect(builds2.dev.length).toBe(2);
+
+		// Builds are newest first
+		const newBuild = builds2.dev[0];
+		expect(newBuild.buildId).toBe(2);
+
+		const oldBuild = builds2.dev[1];
+		expect(oldBuild.buildId).toBe(1);
+	});
+
+	test('Can upload to multiple channels', async () => {
+		const { project, releaseChannels } = await createMockProject(
+			worker,
+			user,
+			undefined,
+			[{ name: 'dev' }, { name: 'release' }],
+		);
+		const devChannel = releaseChannels[0];
+		const releaseChannel = releaseChannels[1];
+
+		// ---- Upload to dev channel ----
+		// Test uploads to dev channel
+		const res = await uploadFile(worker, user, project.name, devChannel.name);
+		expect(res.status).toBe(200);
+
+		const json = await res.json() as ApiResponse;
+		expect(json.success).toBe(true);
+		if (json.success === false) {
+			throw new Error('Expected success to be true');
+		}
+
+		// Confirm build exists
+		let builds = await getBuilds<{ dev: Build[], release: Build[] }>(worker, project);
+		expect(builds.dev).toBeDefined();
+		expect(builds.dev.length).toBe(1);
+
+		const build = builds.dev[0];
+		expect(build.buildId).toBe(1);
+
+		// Upload second build
+		const secondRes = await uploadFile(worker, user, project.name, devChannel.name);
+		expect(secondRes.status).toBe(200);
+
+		const secondJson = await secondRes.json() as ApiResponse;
+		expect(secondJson.success).toBe(true);
+		if (secondJson.success === false) {
+			throw new Error('Expected success to be true');
+		}
+
+		// Confirm build exists
+		builds = await getBuilds<{ dev: Build[], release: Build[] }>(worker, project);
+		expect(builds.dev).toBeDefined();
+		expect(builds.dev.length).toBe(2);
+
+		// Builds are newest first
+		const newBuild = builds.dev[0];
+		expect(newBuild.buildId).toBe(2);
+
+		const oldBuild = builds.dev[1];
+		expect(oldBuild.buildId).toBe(1);
+
+		// ---- Upload to release channel ----
+		// Test uploads to release channel
+		const releaseRes = await uploadFile(worker, user, project.name, releaseChannel.name);
+		expect(releaseRes.status).toBe(200);
+
+		const releaseJson = await releaseRes.json() as ApiResponse;
+		expect(releaseJson.success).toBe(true);
+		if (releaseJson.success === false) {
+			throw new Error('Expected success to be true');
+		}
+
+		// Confirm build exists
+		builds = await getBuilds<{ dev: Build[], release: Build[] }>(worker, project);
+		expect(builds.release).toBeDefined();
+		expect(builds.release.length).toBe(1);
+
+		const releaseBuild = builds.release[0];
+		expect(releaseBuild.buildId).toBe(1);
+
+		// Upload second build
+		const secondReleaseRes = await uploadFile(worker, user, project.name, releaseChannel.name);
+		expect(secondReleaseRes.status).toBe(200);
+
+		const secondReleaseJson = await secondReleaseRes.json() as ApiResponse;
+		expect(secondReleaseJson.success).toBe(true);
+		if (secondReleaseJson.success === false) {
+			throw new Error('Expected success to be true');
+		}
+
+		// Confirm build exists
+		builds = await getBuilds<{ dev: Build[], release: Build[] }>(worker, project);
+		expect(builds.release).toBeDefined();
+		expect(builds.release.length).toBe(2);
+
+		// Builds are newest first
+		const newReleaseBuild = builds.release[0];
+		expect(newReleaseBuild.buildId).toBe(2);
+
+		const oldReleaseBuild = builds.release[1];
+		expect(oldReleaseBuild.buildId).toBe(1);
 	});
 });
+
+interface UploadOptions {
+	blob?: Blob;
+	fileName?: string;
+	checksum?: string;
+}
+
+async function uploadFile(
+	worker: UnstableDevWorker,
+	user: User,
+	projectName: string,
+	releaseChannel: string,
+	opts?: UploadOptions,
+) {
+	const mockJarFile = await createMockJarFile();
+
+	const blob = opts?.blob ?? mockJarFile.blob;
+	const checksum = opts?.checksum ?? '9cd3aad23d91918404f0c619a4bbe92afbebc78288006d4ffe5ae12e97155df8';
+	const fileName = opts?.fileName ?? 'test.jar';
+
+	const formData = new FormData();
+	formData.append('file', blob, fileName);
+	formData.append('metadata', JSON.stringify({
+		checksum,
+	}));
+
+	return worker.fetch(`https://worker.local/api/builds/${projectName}/${releaseChannel}/upload`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${user.apiToken}`,
+		},
+		// @ts-expect-error - unstable_dev doesn't use workers-types
+		body: formData,
+	});
+}
+
+async function getBuilds<T>(worker: UnstableDevWorker, project: Project) {
+	const buildsRes = await worker.fetch(`https://worker.local/api/builds/${project.name}`);
+	expect(buildsRes.status).toBe(200);
+
+	const buildsJson = await buildsRes.json() as ApiResponse;
+
+	expect(buildsJson.success).toBe(true);
+	if (buildsJson.success === false) {
+		throw new Error('Expected success to be true');
+	}
+
+	const builds = buildsJson.data as T;
+	return builds;
+}

--- a/worker/tests/testutils/rand.ts
+++ b/worker/tests/testutils/rand.ts
@@ -1,0 +1,3 @@
+export function randomInt(max?: number): number {
+	return Math.floor(Math.random() * (max ?? 1_000_000));
+}

--- a/worker/tests/testutils/test.ts
+++ b/worker/tests/testutils/test.ts
@@ -1,0 +1,127 @@
+import JSZip from 'jszip';
+import { randomInt } from 'tests/testutils/rand';
+import { expect } from 'vitest';
+import { UnstableDevWorker, unstable_dev } from 'wrangler';
+import { DbQueryBody } from '~/handlers/test/db';
+import { InsertProject, InsertReleaseChannel, InsertUser, Project, ReleaseChannel, User } from '~/store/schema';
+
+export async function setupWorker() {
+	return unstable_dev('src/index.ts', {
+		// Most things will load from the wrangler.toml
+		env: 'dev',
+		vars: {
+			ENVIRONMENT: 'test',
+		},
+
+		updateCheck: false,
+		experimental: {
+			disableExperimentalWarning: true,
+			disableDevRegistry: true,
+			forceLocal: true,
+			testMode: true,
+		},
+	});
+}
+
+export async function populateDb<T = unknown>(worker: UnstableDevWorker, body: DbQueryBody) {
+	const res = await worker.fetch('https://example.com/__test/db', {
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+
+	const json = await res.json() as ApiResponse<T>;
+
+	if (json.success === true) {
+		return json.data;
+	} else {
+		console.log(body);
+		console.log(json);
+		expect(json.error).toBeUndefined();
+		expect(json.success).toBe(true);
+	}
+}
+
+export async function createMockUser(worker: UnstableDevWorker, user?: Partial<InsertUser>) {
+	const randId = randomInt();
+	const userToCreate: InsertUser = {
+		userId: user?.userId ?? randId,
+		name: user?.name ?? `test-user-${randId}`,
+		apiToken: user?.apiToken ?? `mock-api-token-${randId}`,
+	};
+
+	return populateDb<User>(worker, {
+		whatDo: 'newUser',
+		user: userToCreate,
+	});
+}
+
+export async function createMockProject(
+	worker: UnstableDevWorker,
+	user: User,
+	project?: Partial<InsertProject>,
+	releaseChannels?: Partial<InsertReleaseChannel>[],
+) {
+	const randId = randomInt();
+	const projectToCreate: InsertProject = {
+		projectId: project?.projectId ?? randId,
+		name: project?.name ?? `test-project-${randId}`,
+		description: project?.description ?? 'test project',
+		userId: project?.userId ?? user.userId,
+	};
+
+	const createdProject = await populateDb<Project>(worker, {
+		whatDo: 'newProject',
+		project: projectToCreate,
+	});
+
+	if (releaseChannels === undefined) {
+		releaseChannels = [{
+			name: 'Dev',
+			projectId: createdProject.projectId,
+			supportedVersions: '1.0',
+			dependencies: [],
+			fileNaming: '$project.jar',
+		}];
+	}
+
+	const createdReleaseChannels: ReleaseChannel[] = [];
+	for (const releaseChannel of releaseChannels) {
+		const rcToCreate: InsertReleaseChannel = {
+			releaseChannelId: releaseChannel?.releaseChannelId ?? randomInt(),
+			name: releaseChannel?.name ?? 'dev',
+			projectId: createdProject?.projectId,
+			supportedVersions: releaseChannel?.supportedVersions ?? '1.0',
+			dependencies: releaseChannel?.dependencies ?? [],
+			fileNaming: releaseChannel?.fileNaming ?? '$project.jar',
+		};
+
+		const created = await populateDb<ReleaseChannel>(worker, {
+			whatDo: 'newReleaseChannel',
+			releaseChannel: rcToCreate,
+		});
+
+		createdReleaseChannels.push(created);
+	}
+
+	return {
+		project: createdProject,
+		releaseChannels: createdReleaseChannels,
+	};
+}
+
+export async function createMockJarFile(): Promise<{ bytes: ArrayBuffer, blob: Blob }> {
+	const zip = new JSZip();
+	// Create a plugin.yml and main file so that can make this "real"
+	// and so that we can read the plugin.yml on upload
+	// Note: The date is fixed so that the checksum is always the same
+	zip.file('plugin.yml', 'name: test-plugin\nversion: 1.0\nmain: TestPlugin.java', { date: new Date('2023-01-01') });
+	zip.file('TestPlugin.java', 'public class TestPlugin extends JavaPlugin {}', { date: new Date('2023-01-01') });
+
+	const bytes = await zip.generateAsync({ type: 'arraybuffer', compression: 'DEFLATE' });
+	const blob = new Blob([bytes], { type: 'application/java-archive' });
+
+	return {
+		bytes,
+		blob,
+	};
+}

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+});


### PR DESCRIPTION
This changes the build ID to be per project/env instead of being global. This means no more weird build numbers

If I have 2 release channels, dev and release. If I upload a build to `dev`, it'll be build 1. If I upload a build to `release`, it'll also be build 1.

Finally also wrote some tests, most of upload validation is covered now along with the new build ID behaviour.

Still to do:
* Confirm 100% migration will work as expected (and uncomment drop table)