### PR TITLE
feat: add patchReleaseChannel endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ node_modules/
 .cache/
 dist/
 .turbo/
-
-.dev.vars
-
 .vscode/
 .idea/
+
+.dev.vars

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 .turbo/
 
 .dev.vars
+
+.vscode/
+.idea/

--- a/worker/src/handlers/projects/project.ts
+++ b/worker/src/handlers/projects/project.ts
@@ -213,6 +213,7 @@ export async function patchReleaseChannel(ctx: Ctx, body: PatchProjectReleaseCha
 		return errors.ReleaseChannelNotFound.toResponse(ctx);
 	}
 
-	await ReleaseChannelStore.updateReleaseChannel(releaseChannel.releaseChannelId, body);
-	return success('Release channel updated!', releaseChannel);
+	const updatedReleaseChannel = await ReleaseChannelStore.updateReleaseChannel(releaseChannel.releaseChannelId, body);
+
+	return success('Release channel updated!', updatedReleaseChannel);
 }

--- a/worker/src/handlers/projects/project.ts
+++ b/worker/src/handlers/projects/project.ts
@@ -112,10 +112,10 @@ export const newProjectSchema = z.object({
 	]),
 });
 
-type Body = z.infer<typeof newProjectSchema>;
+type NewProjectBody = z.infer<typeof newProjectSchema>;
 
 // POST /api/projects/:projectName/new
-export async function postNewProject(ctx: Ctx, body: Body) {
+export async function postNewProject(ctx: Ctx, body: NewProjectBody) {
 	const userId = ctx.get('userId');
 
 	// Verify no existing project with that name exists (for this user)
@@ -184,4 +184,35 @@ export async function patchProjectSettings(ctx: Ctx, body: ProjectSettingsBody) 
 	const updatedSettings = await ProjectSettingStore.updateSettings(project.projectId, body);
 
 	return success('Settings updated!', updatedSettings);
+}
+
+export const patchProjectReleaseChannelSchema = z.object({
+	name: z.string().default('Dev'),
+	supportedVersions: z.string().default('Unknown'),
+	dependencies: z.array(z.string()).default([]),
+	fileNaming: z.string().default('$project.jar'),
+});
+
+type PatchProjectReleaseChannelBody = z.infer<typeof patchProjectReleaseChannelSchema>;
+
+// PATCH /api/projects/:projectName/:releaseChannel
+export async function patchReleaseChannel(ctx: Ctx, body: PatchProjectReleaseChannelBody) {
+	const userId = ctx.get('userId');
+	const projectName = ctx.req.param('projectName');
+
+	// Get project
+	const project = await ProjectStore.getProjectByNameAndUser(projectName, userId);
+	if (project === undefined) {
+		return errors.ProjectNotFound.toResponse(ctx);
+	}
+
+	// Get release channel
+	const releaseChannels = await ReleaseChannelStore.getReleaseChannelsForProject(project.projectId);
+	const releaseChannel = releaseChannels.find(channel => channel.name === ctx.req.param('releaseChannel'));
+	if (releaseChannel === undefined) {
+		return errors.ReleaseChannelNotFound.toResponse(ctx);
+	}
+
+	await ReleaseChannelStore.updateReleaseChannel(releaseChannel.releaseChannelId, body);
+	return success('Release channel updated!', releaseChannel);
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -20,6 +20,8 @@ import {
 	postNewProject,
 	patchProjectSchema,
 	patchProject,
+	patchProjectReleaseChannelSchema,
+	patchReleaseChannel,
 } from '~/handlers/projects/project';
 import { dbQueryHandler, dbQuerySchema } from '~/handlers/test/db';
 import { testOnlyMiddleware } from '~/handlers/test/middleware';
@@ -73,6 +75,11 @@ app.patch(
 	'/api/projects/:projectName/settings',
 	auth,
 	jsonValidator(projectSettingsSchema, patchProjectSettings),
+);
+app.patch(
+	'/api/projects/:projectName/:releaseChannel',
+	auth,
+	jsonValidator(patchProjectReleaseChannelSchema, patchReleaseChannel),
 );
 
 // Builds

--- a/worker/src/store/ReleaseChannelStore.ts
+++ b/worker/src/store/ReleaseChannelStore.ts
@@ -38,6 +38,15 @@ class _ReleaseChannelStore {
 			.values(Array.isArray(releaseChannel) ? releaseChannel : [releaseChannel])
 			.returning();
 	}
+
+	updateReleaseChannel(releaseChannelId: number, releaseChannel: Partial<InsertReleaseChannel>): Promise<ReleaseChannel> {
+		return getDb()
+			.update(releaseChannels)
+			.set(releaseChannel)
+			.where(eq(releaseChannels.releaseChannelId, releaseChannelId))
+			.returning()
+			.get();
+	}
 }
 
 const ReleaseChannelStore = new _ReleaseChannelStore();


### PR DESCRIPTION
I'm not sure if I missed something, but local env seems to work well.

patch request via Postman:
<img width="687" alt="image" src="https://github.com/WalshyDev/blob-builds/assets/7105953/b046f7fb-4efc-44a2-877a-7f521bcff477">

Get the project info after updating:
<img width="590" alt="image" src="https://github.com/WalshyDev/blob-builds/assets/7105953/5a8acc22-b1d7-4d4d-a913-8042fa5f1595">
