### PR TITLE
Added a global search

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,6 +2,7 @@ import cloudflare from '@astrojs/cloudflare';
 import react from '@astrojs/react';
 import tailwind from '@astrojs/tailwind';
 import { defineConfig } from 'astro/config';
+import proxyMiddleware from './plugins/proxy-middleware';
 
 // https://astro.build/config
 export default defineConfig({
@@ -9,6 +10,11 @@ export default defineConfig({
 	integrations: [
 		tailwind(),
 		react(),
+		proxyMiddleware({
+			pathFilter: '/api',
+			target: 'http://localhost:8787',
+			changeOrigin: true,
+		}),
 	],
 	adapter: cloudflare({
 		platformProxy: {

--- a/site/package.json
+++ b/site/package.json
@@ -31,5 +31,8 @@
 	},
 	"devDependencies": {
 		"http-proxy-middleware": "3.0.0"
+	},
+	"overrides": {
+		"@types/node": "20.8.3"
 	}
 }

--- a/site/plugins/proxy-middleware.ts
+++ b/site/plugins/proxy-middleware.ts
@@ -1,0 +1,15 @@
+import { createProxyMiddleware, type Options } from 'http-proxy-middleware';
+import type { ViteDevServer } from 'vite';
+
+export default (options: Options) => {
+	const apiProxy = createProxyMiddleware(options);
+
+	return {
+		name: 'proxy',
+		hooks: {
+			'astro:server:setup': ({ server }: { server: ViteDevServer }) => {
+				server.middlewares.use(apiProxy);
+			},
+		},
+	};
+};

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -53,7 +53,7 @@ export function _fetch<T = unknown>(
 		.then((res) => res.json() as Promise<ApiResponse<T>>);
 }
 
-type ApiResponse<T = unknown> = ApiResponseSuccess<T> | ApiResponseError;
+export type ApiResponse<T = unknown> = ApiResponseSuccess<T> | ApiResponseError;
 
 interface ApiResponseSuccess<T = unknown> {
 	success: true;

--- a/site/src/api/utils.ts
+++ b/site/src/api/utils.ts
@@ -1,0 +1,14 @@
+export function buildProjectList(projects: ProjectResponse[]): ProjectList {
+	const projectList: ProjectList = {};
+	
+	for (const proj of projects) {
+		const existing = projectList[proj.owner!];
+		if (existing  !== undefined) {
+			existing.push(proj);
+		} else {
+			projectList[proj.owner!] = [proj];
+		}
+	}
+
+	return projectList;
+}

--- a/site/src/components/html/Input.tsx
+++ b/site/src/components/html/Input.tsx
@@ -10,14 +10,14 @@ const icons: Icons = {
 };
 
 interface IconProps {
-	name: string;
+	name?: string | undefined;
 	icon?: keyof typeof icons;
 	iconPosition?: 'left' | 'right';
 	iconClickable?: boolean | undefined;
 }
 
 interface Props extends React.InputHTMLAttributes<HTMLInputElement>, IconProps {
-	name: string;
+	name?: string | undefined;
 	label?: string;
 	labelClassName?: string;
 	hidden?: boolean;

--- a/site/src/components/projects/SearchableProjects.tsx
+++ b/site/src/components/projects/SearchableProjects.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { ProjectList } from '~/components/projects/ProjectGroup';
+import SearchBar from '~/components/search/SearchBar';
+import type { SearchBarProps } from '~/components/search/SearchBar';
+
+type Props = {
+	projects: ProjectList;
+	'client:load': boolean;
+} & SearchBarProps;
+
+export default function UniversalSearch({ projects, ...searchBarProps }: Props) {
+	const [search, setSearch] = useState('');
+
+	useEffect(() => {
+		console.log('searching', search);
+		if (!search) {
+			return;
+		}
+
+		// fetch('/api/search', {
+		// 	method: 'POST',
+		// 	body: JSON.stringify({ query: search }),
+		// 	headers: {
+		// 		'Content-Type': 'application/json',
+		// 	},
+		// })
+		// 	.then(async (res) => console.log(await res.text()));
+		// .then((res) => res.json())
+		// .then((json) => console.log(json));
+	}, [search]);
+
+	return (
+		<>
+			<SearchBar
+				{...searchBarProps}
+				onChange={(event) => setSearch(event.target.value)}
+			/>
+
+			<ProjectList projects={projects} />
+		</>
+	);
+}

--- a/site/src/components/projects/SearchableProjects.tsx
+++ b/site/src/components/projects/SearchableProjects.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
+import { buildProjectList } from '~/api/utils';
 import { ProjectList } from '~/components/projects/ProjectGroup';
 import SearchBar from '~/components/search/SearchBar';
+import type { ApiResponse } from '~/api/api';
 import type { SearchBarProps } from '~/components/search/SearchBar';
 
 type Props = {
@@ -8,8 +10,9 @@ type Props = {
 	'client:load': boolean;
 } & SearchBarProps;
 
-export default function UniversalSearch({ projects, ...searchBarProps }: Props) {
+export default function UniversalSearch({ projects: projectList, ...searchBarProps }: Props) {
 	const [search, setSearch] = useState('');
+	const [projects, setProjects] = useState<ProjectList>(projectList);
 
 	useEffect(() => {
 		console.log('searching', search);
@@ -17,16 +20,26 @@ export default function UniversalSearch({ projects, ...searchBarProps }: Props) 
 			return;
 		}
 
-		// fetch('/api/search', {
-		// 	method: 'POST',
-		// 	body: JSON.stringify({ query: search }),
-		// 	headers: {
-		// 		'Content-Type': 'application/json',
-		// 	},
-		// })
-		// 	.then(async (res) => console.log(await res.text()));
-		// .then((res) => res.json())
-		// .then((json) => console.log(json));
+		fetch('/api/search', {
+			method: 'POST',
+			body: JSON.stringify({ query: search }),
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		})
+			.then((res) => res.json() as Promise<ApiResponse<ProjectResponse[]>>)
+			.then((json) => {
+				console.log('json', json);
+				if (json.success === true) {
+					const projectList = buildProjectList(json.data);
+
+					console.log('set projects', projectList);
+					setProjects(projectList);
+				} else{
+					console.error('Failed to search for projects:', json.error);
+					setProjects({});
+				}
+			});
 	}, [search]);
 
 	return (

--- a/site/src/components/search/SearchBar.tsx
+++ b/site/src/components/search/SearchBar.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import Input from '~/components/html/Input';
+
+export interface SearchBarProps {
+	className?: string;
+	name?: string;
+	placeholder?: string;
+	hideWithoutJs?: boolean;
+	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function SearchBar({ className, name, placeholder, hideWithoutJs, onChange }: SearchBarProps) {
+	const [hidden, setHidden] = useState(hideWithoutJs);
+	// We're in client-side land, we can render the search
+	useEffect(() => {
+		if (hidden === true && typeof window !== 'undefined') {
+			hideWithoutJs = false;
+			setHidden(false);
+		}
+	}, []);
+
+	return (
+		<div className={className}>
+			<Input
+				name={name}
+				placeholder={placeholder}
+				className={hidden ? 'hidden' : ''}
+				onChange={onChange}
+			/>
+		</div>
+	);
+}

--- a/site/src/pages/api/[...path].ts
+++ b/site/src/pages/api/[...path].ts
@@ -1,5 +1,7 @@
-import type { APIContext } from 'astro';
+// import type { APIContext } from 'astro';
 
+// TODO: API routes seem broken right now with getPlatformProxy
+/*
 export async function ALL({ request, locals }: APIContext): Promise<Response> {
 	// return new Response('{}', { headers: { 'content-type': 'application/json' } });
 
@@ -10,3 +12,4 @@ export async function ALL({ request, locals }: APIContext): Promise<Response> {
 	console.log(`[api route] ${request.url} => ${res.status}`, res);
 	return res;
 }
+*/

--- a/site/src/pages/api/[...path].ts
+++ b/site/src/pages/api/[...path].ts
@@ -1,5 +1,12 @@
 import type { APIContext } from 'astro';
 
-export async function GET({ request, locals }: APIContext) {
-	return locals.runtime.env.API.fetch(request);
+export async function ALL({ request, locals }: APIContext): Promise<Response> {
+	// return new Response('{}', { headers: { 'content-type': 'application/json' } });
+
+	// TODO: Debug
+	// Astro is failing if you pass a Request object directly to fetch
+	// Astro also seems to be failing on the Response class...
+	const res = await locals.runtime.env.API.fetch(request.url, request);
+	console.log(`[api route] ${request.url} => ${res.status}`, res);
+	return res;
 }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '~/layouts/Layout.astro';
-import { ProjectList } from '~/components/projects/ProjectGroup';
 import { getProjects } from '~/api/api';
+import SearchableProjects from '~/components/projects/SearchableProjects';
 
 let projects: ProjectResponse[] = [];
 
@@ -26,6 +26,12 @@ for (const proj of projects) {
 
 <Layout>
 	<main>
-		<ProjectList projects={projectList} />
+		<SearchableProjects
+			placeholder='Search project...'
+			className='w-4/5 mx-auto my-4'
+			hideWithoutJs
+			projects={projectList}
+			client:load
+		/>
 	</main>
 </Layout>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from '~/layouts/Layout.astro';
 import { getProjects } from '~/api/api';
 import SearchableProjects from '~/components/projects/SearchableProjects';
+import { buildProjectList } from '~/api/utils';
 
 let projects: ProjectResponse[] = [];
 
@@ -13,15 +14,7 @@ if (res.success) {
 	console.error(res.error);
 }
 
-const projectList: ProjectList = {};
-for (const proj of projects) {
-	const existing = projectList[proj.owner!];
-	if (existing  !== undefined) {
-		existing.push(proj);
-	} else {
-		projectList[proj.owner!] = [proj];
-	}
-}
+const projectList = buildProjectList(projects);
 ---
 
 <Layout>

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -47,3 +47,7 @@ interface BuildResponse {
 	commitHash?: string;
 	commitLink?: string;
 }
+
+interface UserResponse {
+	name: string;
+}

--- a/worker/src/handlers/search/search.ts
+++ b/worker/src/handlers/search/search.ts
@@ -5,7 +5,11 @@ import ProjectStore from '~/store/ProjectStore';
 import { Ctx } from '~/types/hono';
 
 export const searchSchema = z.object({
-	query: z.string().max(100, 'Query is too long'),
+	query: z.string({
+		required_error: 'query is required',
+		invalid_type_error: 'query must be a string',
+	})
+		.max(100, 'query needs to be at most 100 characters'),
 });
 
 export type SearchBody = z.infer<typeof searchSchema>;

--- a/worker/src/handlers/search/search.ts
+++ b/worker/src/handlers/search/search.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { success } from '~/api/api';
+import { toProjectResponse } from '~/api/response';
+import ProjectStore from '~/store/ProjectStore';
+import { Ctx } from '~/types/hono';
+
+export const searchSchema = z.object({
+	query: z.string().max(100, 'Query is too long'),
+});
+
+export type SearchBody = z.infer<typeof searchSchema>;
+
+// POST /api/search
+export async function postSearch(_: Ctx, body: SearchBody) {
+	const projects = await ProjectStore.getProjectsWithSearchTerm(body.query);
+
+	const projectResponses: ProjectResponse[] = [];
+	for (const project of projects) {
+		projectResponses.push(toProjectResponse(project, project.defaultReleaseChannel));
+	}
+
+	return success('Success', projectResponses);
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -23,6 +23,7 @@ import {
 	patchProjectReleaseChannelSchema,
 	patchReleaseChannel,
 } from '~/handlers/projects/project';
+import { postSearch, searchSchema } from '~/handlers/search/search';
 import { getUser } from '~/handlers/users/user';
 import { adminOnly } from '~/middleware/admin';
 import { auth } from '~/middleware/auth';
@@ -130,6 +131,12 @@ app.get(
 app.get(
 	'/api/auth/oauth/github/callback',
 	githubCallback,
+);
+
+// -- Search --
+app.post(
+	'/api/search',
+	jsonValidator(searchSchema, postSearch),
 );
 
 // -- Admin --

--- a/worker/src/store/ProjectStore.ts
+++ b/worker/src/store/ProjectStore.ts
@@ -83,6 +83,9 @@ class _ProjectStore {
 
 	// TODO: This still sucks
 	async getProjectsWithSearchTerm(searchTerm: string): Promise<ProjectListNew> {
+		// Wrap the search term in % to make it a wildcard search
+		searchTerm = `%${searchTerm}%`;
+
 		// Get all projects with the owner name
 		const projs: ({ owner: string } & Project)[] = await getDb()
 			.select({

--- a/worker/src/store/ProjectStore.ts
+++ b/worker/src/store/ProjectStore.ts
@@ -1,4 +1,4 @@
-import { and, eq, ilike, inArray, like, or, sql } from 'drizzle-orm';
+import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
 import { projects, releaseChannels, users } from '~/store/schema';
 import { getDb } from '~/utils/storage';
 import type { InsertProject, Project, ReleaseChannel } from '~/store/schema';

--- a/worker/tests/handlers/search/search.test.ts
+++ b/worker/tests/handlers/search/search.test.ts
@@ -1,0 +1,143 @@
+import { applyD1Migrations, env } from 'cloudflare:test';
+import { TestRequest } from 'tests/testutils/request';
+import { createProject, createUser } from 'tests/testutils/seed';
+import { describe, test, expect, beforeEach } from 'vitest';
+import * as errors from '~/api/errors';
+
+describe('/api/search', () => {
+	beforeEach(async () => {
+		await applyD1Migrations(env.DB, env.MIGRATIONS);
+	});
+
+	describe('Happy path', () => {
+		test('Can search projects', async () => {
+			const userOne = await createUser(env, { name: 'user-1' });
+			const userTwo = await createUser(env, { name: 'user-2' });
+
+			// Create a few projects
+			const testProjectOne = await createProject(env, userOne, { name: 'test1' });
+			const testProjectTwo = await createProject(env, userOne, { name: 'test-2' });
+			// Third project is owned by a different user
+			const testProjectThree = await createProject(env, userTwo, { name: 'abc-test' });
+			// Should not be matched
+			const testProjectFour = await createProject(env, userOne, { name: 'abcdef' });
+			
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({ query: 'test' }).run();
+			res.expectStatus(200);
+			res.expectSuccessful();
+			res.expectData();
+
+			const body = res.getData<ProjectResponse[]>();
+			expect(body).toHaveLength(3);
+
+			const projectNames = body.map((p) => p.name);
+			expect(projectNames).toContain(testProjectOne.name);
+			expect(projectNames).toContain(testProjectTwo.name);
+			expect(projectNames).toContain(testProjectThree.name);
+			expect(projectNames).not.toContain(testProjectFour.name);
+		});
+
+		test('Can search users', async () => {
+			const userOne = await createUser(env, { name: 'user-1' });
+			const userTwo = await createUser(env, { name: 'user-2' });
+			const userThree = await createUser(env, { name: 'walshy' });
+
+			// Create a few projects
+			const testProjectOne = await createProject(env, userOne, { name: 'test1' });
+			const testProjectTwo = await createProject(env, userOne, { name: 'test-2' });
+			// Third project is owned by a different user
+			const testProjectThree = await createProject(env, userTwo, { name: 'abc-test' });
+			// Should not be matched
+			const testProjectFour = await createProject(env, userThree, { name: 'abcdef' });
+			
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({ query: 'user' }).run();
+			res.expectStatus(200);
+			res.expectSuccessful();
+			res.expectData();
+
+			const body = res.getData<ProjectResponse[]>();
+			expect(body).toHaveLength(3);
+
+			const projectNames = body.map((p) => p.name);
+			expect(projectNames).toContain(testProjectOne.name);
+			expect(projectNames).toContain(testProjectTwo.name);
+			expect(projectNames).toContain(testProjectThree.name);
+			expect(projectNames).not.toContain(testProjectFour.name);
+		});
+
+		test('Can search projects and users', async () => {
+			const userOne = await createUser(env, { name: 'user-1' });
+			const userTwo = await createUser(env, { name: 'user-2' });
+			const userThree = await createUser(env, { name: 'walshy-test' });
+
+			// Create a few projects
+			const testProjectOne = await createProject(env, userOne, { name: 'test1' });
+			const testProjectTwo = await createProject(env, userOne, { name: 'test-2' });
+			// Third project is owned by a different user
+			const testProjectThree = await createProject(env, userTwo, { name: 'abc-test' });
+			// Should not be matched
+			const testProjectFour = await createProject(env, userThree, { name: 'abcdef' });
+			
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({ query: 'test' }).run();
+			res.expectStatus(200);
+			res.expectSuccessful();
+			res.expectData();
+
+			const body = res.getData<ProjectResponse[]>();
+			expect(body).toHaveLength(4);
+
+			const projectNames = body.map((p) => p.name);
+			expect(projectNames).toContain(testProjectOne.name);   // Matched project naem
+			expect(projectNames).toContain(testProjectTwo.name);   // Matched project naem
+			expect(projectNames).toContain(testProjectThree.name); // Matched project naem
+			expect(projectNames).toContain(testProjectFour.name);  // Matched user name
+		});
+
+		test('Exact match should return one value', async () => {
+			const userOne = await createUser(env, { name: 'user-1' });
+			const userTwo = await createUser(env, { name: 'user-2' });
+			const userThree = await createUser(env, { name: 'walshy-test' });
+
+			// Create a few projects
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const _proj1 = await createProject(env, userOne, { name: 'test1' });
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const _proj2 = await createProject(env, userOne, { name: 'test-2' });
+			// Third project is owned by a different user
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const _proj3 = await createProject(env, userTwo, { name: 'abc-test' });
+			// Should not be matched
+			const testProjectFour = await createProject(env, userThree, { name: 'abcdef' });
+			
+			// Exact match project
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({ query: 'abcdef' }).run();
+			res.expectStatus(200);
+			res.expectSuccessful();
+			res.expectData();
+
+			const body = res.getData<ProjectResponse[]>();
+			expect(body).toHaveLength(1);
+			expect(body[0].name).toBe(testProjectFour.name);
+		});
+	});
+
+	describe('Validation', () => {
+		test('Query is required', async () => {
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({}).run();
+			res.expectFailure();
+			res.expectError(errors.InvalidJson('query is required'));
+		});
+
+		test('Query needs to be a string', async () => {
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({ query: 1 }).run();
+			res.expectFailure();
+			res.expectError(errors.InvalidJson('query must be a string'));
+		});
+
+		test('Query cannot be too long', async () => {
+			const res = await TestRequest.new('/api/search', { method: 'POST' }).withJson({ query: 'a'.repeat(101) }).run();
+			res.expectFailure();
+			res.expectError(errors.InvalidJson('query needs to be at most 100 characters'));
+		});
+	});
+});

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -5,10 +5,12 @@ compatibility_date = "2023-11-21"
 compatibility_flags = ["nodejs_compat"]
 logpush = true
 
-[placement]
-mode = "smart"
-
 [env.production]
+routes = [
+	{ pattern = "blob.build/api/*", zone_name = "blob.build" },
+	{ pattern = "blob.build/builds/*", zone_name = "blob.build" },
+]
+
 [env.production.vars]
 ENVIRONMENT = "production"
 # Secret: SENTRY_DSN
@@ -19,6 +21,9 @@ GITHUB_CLIENT_ID = "d513c731f2ba83a0fec2"
 
 [env.production.version_metadata]
 binding = "VERSION_METADATA"
+
+[env.production.placement]
+mode = "smart"
 
 [[env.production.d1_databases]]
 binding = "DB"
@@ -35,6 +40,11 @@ binding = "AE"
 dataset = "blob_builds_production"
 
 [env.dev]
+routes = [
+	{ pattern = "staging.blob.build/api/*", zone_name = "blob.build" },
+	{ pattern = "staging.blob.build/builds/*", zone_name = "blob.build" },
+]
+
 [env.dev.vars]
 ENVIRONMENT = "dev"
 # Secret: SENTRY_DSN
@@ -45,6 +55,9 @@ GITHUB_CLIENT_ID = "e776a0171c7c88d6ceec"
 
 [env.dev.version_metadata]
 binding = "VERSION_METADATA"
+
+[env.dev.placement]
+mode = "smart"
 
 [[env.dev.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
This will search by both projects and users not just projects. Does nice partial matching and stuff. 
This was a bit of a pain to do with SSR first but hey, it actually works pretty nicely.

We will render everything server-side with the search bar hidden. Once rendered, the search bar will be unhidden, this does mean it pops out which is a bit annoying - could add a space here but it looks a bit odd. Not decided yet what I'll do.
Once rendered client-side, the React acts like it normally does so I can use my state and hooks like normal. Was a good exercise on how to do this stuff with Astro.

Project search:
![image](https://github.com/WalshyDev/blob-builds/assets/8492901/ea01915f-15d0-44ce-bf06-23cbc223ba6d)

User search:
![image](https://github.com/WalshyDev/blob-builds/assets/8492901/f1b9c7c6-caa4-47fc-b216-765682e5829e)

Still do do:
- [x] Test for search
- [ ] Make search not pop out?